### PR TITLE
Tiny modification in network and solver according to latest caffe api  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.caffemodel
+*.solverstate
+*.h5
+*.txt
+data/

--- a/kaggle_prototxt/fkp_deploy.prototxt
+++ b/kaggle_prototxt/fkp_deploy.prototxt
@@ -1,7 +1,7 @@
 name: "fkp_net"
-layers {
+layer {
   name: "data"
-  type: MEMORY_DATA
+  type: "MemoryData"
   top: "data"
   top: "label"
   memory_data_param {
@@ -12,14 +12,21 @@ layers {
 
   }
 }
-
-layers {
+layer {
   name: "conv1"
-  type: CONVOLUTION
+  type: "Convolution"
   bottom: "data"
   top: "conv1"
-  blobs_lr: 1
-  blobs_lr: 2
+  #blobs_lr: 1
+  #blobs_lr: 2
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 20
     kernel_size: 5
@@ -34,16 +41,15 @@ layers {
     }
   }
 }
-layers {
+layer {
   name: "relu1"
-  type: RELU
+  type: "ReLU"
   bottom: "conv1"
   top: "conv1"
 }
-
-layers {
+layer {
   name: "pool1"
-  type: POOLING
+  type: "Pooling"
   bottom: "conv1"
   top: "pool1"
   pooling_param {
@@ -52,7 +58,6 @@ layers {
     stride: 2
   }
 }
-
 layer {
   name: "dropout1"
   type: "Dropout"
@@ -62,14 +67,21 @@ layer {
     dropout_ratio: 0.1
   }
 }
-
-layers {
+layer {
   name: "conv2"
-  type: CONVOLUTION
+  type: "Convolution"
   bottom: "pool1"
   top: "conv2"
-  blobs_lr: 1
-  blobs_lr: 2
+  #blobs_lr: 1
+  #blobs_lr: 2
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 48
     kernel_size: 5
@@ -77,7 +89,6 @@ layers {
     weight_filler {
       type: "xavier"
       variance_norm: AVERAGE
-
     }
     bias_filler {
       type: "constant"
@@ -85,16 +96,15 @@ layers {
     }
   }
 }
-layers {
+layer {
   name: "relu2"
-  type: RELU
+  type: "ReLU"
   bottom: "conv2"
   top: "conv2"
 }
-
-layers {
+layer {
   name: "pool2"
-  type: POOLING
+  type: "Pooling"
   bottom: "conv2"
   top: "pool2"
   pooling_param {
@@ -103,7 +113,6 @@ layers {
     stride: 2
   }
 }
-
 layer {
   name: "dropout2"
   type: "Dropout"
@@ -113,14 +122,21 @@ layer {
     dropout_ratio: 0.3
   }
 }
-
-layers {
+layer {
   name: "conv3"
-  type: CONVOLUTION
+  type: "Convolution"
   bottom: "pool2"
   top: "conv3"
-  blobs_lr: 1
-  blobs_lr: 2
+  #blobs_lr: 1
+  #blobs_lr: 2
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 64
     kernel_size: 3
@@ -136,14 +152,12 @@ layers {
     }
   }
  }
- layers {
+ layer {
   name: "relu3"
-  type: RELU
+  type: "ReLU"
   bottom: "conv3"
   top: "conv3"
 }
-
-
 layer {
   name: "dropout3"
   type: "Dropout"
@@ -153,17 +167,23 @@ layer {
     dropout_ratio: 0.5
   }
 }
-
-
-layers {
+layer {
   name: "fc5"
-  type: INNER_PRODUCT
+  type: "InnerProduct"
   bottom: "conv3"
   top: "fc5"
-  blobs_lr: 1
-  blobs_lr: 2
-  weight_decay: 1
-  weight_decay: 0
+  #blobs_lr: 1
+  #blobs_lr: 2
+  #weight_decay: 1
+  #weight_decay: 0
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
   inner_product_param {
     num_output: 500
     weight_filler {
@@ -176,7 +196,6 @@ layers {
     }
   }
 }
-
 layer {
   name: "drop4"
   type: "Dropout"
@@ -186,17 +205,23 @@ layer {
     dropout_ratio: 0.5
   }
 }
-
-
-layers {
+layer {
   name: "fc6"
-  type: INNER_PRODUCT
+  type: "InnerProduct"
   bottom: "fc5"
   top: "fc6"
-  blobs_lr: 1
-  blobs_lr: 2
-  weight_decay: 1
-  weight_decay: 0
+  #blobs_lr: 1
+  #blobs_lr: 2
+  #weight_decay: 1
+  #weight_decay: 0
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
   inner_product_param {
     num_output: 30
     weight_filler {

--- a/kaggle_prototxt/fkp_net.prototxt
+++ b/kaggle_prototxt/fkp_net.prototxt
@@ -5,7 +5,7 @@ layer {
   top: "data"
   top: "label"
   hdf5_data_param {
-    source: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_fkp_data/train_data_list.txt"
+    source: "caffe-regression/kaggle_fkp_data/train_data_list.txt"
     batch_size: 128
     shuffle: true
   }
@@ -17,7 +17,7 @@ layer {
   top: "data"
   top: "label"
   hdf5_data_param {
-    source: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_fkp_data/val_data_list.txt"
+    source: "caffe-regression/kaggle_fkp_data/val_data_list.txt"
     batch_size: 540
   }
   include: { phase: TEST }

--- a/kaggle_prototxt/fkp_net.prototxt
+++ b/kaggle_prototxt/fkp_net.prototxt
@@ -1,34 +1,42 @@
 name: "fkp_net"
-layers {
+layer {
   name: "MyData"
-  type: HDF5_DATA
+  type: "HDF5Data"
   top: "data"
   top: "label"
   hdf5_data_param {
-    source: "data/kaggle_fkp_data/train_data_list.txt"
+    source: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_fkp_data/train_data_list.txt"
     batch_size: 128
     shuffle: true
   }
   include: { phase: TRAIN }
 }
-layers {
+layer {
   name: "MyData"
-  type: HDF5_DATA
+  type: "HDF5Data"
   top: "data"
   top: "label"
   hdf5_data_param {
-    source: "data/kaggle_fkp_data/val_data_list.txt"
+    source: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_fkp_data/val_data_list.txt"
     batch_size: 540
   }
   include: { phase: TEST }
 }
-layers {
+layer {
   name: "conv1"
-  type: CONVOLUTION
+  type: "Convolution"
   bottom: "data"
   top: "conv1"
-  blobs_lr: 1
-  blobs_lr: 2
+  #blobs_lr: 1
+  #blobs_lr: 2
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 20
     kernel_size: 5
@@ -43,16 +51,15 @@ layers {
     }
   }
 }
-layers {
+layer {
   name: "relu1"
-  type: RELU
+  type: "ReLU"
   bottom: "conv1"
   top: "conv1"
 }
-
-layers {
+layer {
   name: "pool1"
-  type: POOLING
+  type: "Pooling"
   bottom: "conv1"
   top: "pool1"
   pooling_param {
@@ -61,7 +68,6 @@ layers {
     stride: 2
   }
 }
-
 layer {
   name: "dropout1"
   type: "Dropout"
@@ -71,14 +77,21 @@ layer {
     dropout_ratio: 0.1
   }
 }
-
-layers {
+layer {
   name: "conv2"
-  type: CONVOLUTION
+  type: "Convolution"
   bottom: "pool1"
   top: "conv2"
-  blobs_lr: 1
-  blobs_lr: 2
+  #blobs_lr: 1
+  #blobs_lr: 2
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 48
     kernel_size: 5
@@ -86,7 +99,6 @@ layers {
     weight_filler {
       type: "xavier"
       variance_norm: AVERAGE
-
     }
     bias_filler {
       type: "constant"
@@ -94,16 +106,15 @@ layers {
     }
   }
 }
-layers {
+layer {
   name: "relu2"
-  type: RELU
+  type: "ReLU"
   bottom: "conv2"
   top: "conv2"
 }
-
-layers {
+layer {
   name: "pool2"
-  type: POOLING
+  type: "Pooling"
   bottom: "conv2"
   top: "pool2"
   pooling_param {
@@ -112,7 +123,6 @@ layers {
     stride: 2
   }
 }
-
 layer {
   name: "dropout2"
   type: "Dropout"
@@ -122,14 +132,21 @@ layer {
     dropout_ratio: 0.3
   }
 }
-
-layers {
+layer {
   name: "conv3"
-  type: CONVOLUTION
+  type: "Convolution"
   bottom: "pool2"
   top: "conv3"
-  blobs_lr: 1
-  blobs_lr: 2
+  #blobs_lr: 1
+  #blobs_lr: 2
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 64
     kernel_size: 3
@@ -145,14 +162,12 @@ layers {
     }
   }
  }
- layers {
+ layer {
   name: "relu3"
-  type: RELU
+  type: "ReLU"
   bottom: "conv3"
   top: "conv3"
 }
-
-
 layer {
   name: "dropout3"
   type: "Dropout"
@@ -162,17 +177,23 @@ layer {
     dropout_ratio: 0.5
   }
 }
-
-
-layers {
+layer {
   name: "fc5"
-  type: INNER_PRODUCT
+  type: "InnerProduct"
   bottom: "conv3"
   top: "fc5"
-  blobs_lr: 1
-  blobs_lr: 2
-  weight_decay: 1
-  weight_decay: 0
+  #blobs_lr: 1
+  #blobs_lr: 2
+  #weight_decay: 1
+  #weight_decay: 0
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
   inner_product_param {
     num_output: 500
     weight_filler {
@@ -185,7 +206,6 @@ layers {
     }
   }
 }
-
 layer {
   name: "drop4"
   type: "Dropout"
@@ -195,17 +215,23 @@ layer {
     dropout_ratio: 0.5
   }
 }
-
-
-layers {
+layer {
   name: "fc6"
-  type: INNER_PRODUCT
+  type: "InnerProduct"
   bottom: "fc5"
   top: "fc6"
-  blobs_lr: 1
-  blobs_lr: 2
-  weight_decay: 1
-  weight_decay: 0
+  #blobs_lr: 1
+  #blobs_lr: 2
+  #weight_decay: 1
+  #weight_decay: 0
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
   inner_product_param {
     num_output: 30
     weight_filler {
@@ -218,10 +244,9 @@ layers {
     }
   }
 }
-
-layers {
+layer {
   name: "loss"
-  type: EUCLIDEAN_LOSS
+  type: "EuclideanLoss"
   bottom: "fc6"
   bottom: "label"
   top: "loss"

--- a/kaggle_prototxt/fkp_solver.prototxt
+++ b/kaggle_prototxt/fkp_solver.prototxt
@@ -1,5 +1,5 @@
 # The training protocol buffer definition
-net: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_prototxt/fkp_net.prototxt"
+net: "caffe-regression/kaggle_prototxt/fkp_net.prototxt"
 # The testing protocol buffer definition
 # test_iter specifies how many forward passes the test should carry out.
 # In the case of facialpoint, we have test batch size 80 and 43 test iterations,
@@ -23,7 +23,7 @@ display: 100
 max_iter: 1000000
 # snapshot intermediate results
 snapshot: 5000
-snapshot_prefix: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_prototxt/model/fkp"
+snapshot_prefix: "caffe-regression/kaggle_prototxt/model/fkp"
 # solver mode: CPU or GPU
 solver_mode: GPU
 

--- a/kaggle_prototxt/fkp_solver.prototxt
+++ b/kaggle_prototxt/fkp_solver.prototxt
@@ -1,5 +1,5 @@
 # The training protocol buffer definition
-net: "examples/kaggle_prototxt/fkp_net.prototxt"
+net: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_prototxt/fkp_net.prototxt"
 # The testing protocol buffer definition
 # test_iter specifies how many forward passes the test should carry out.
 # In the case of facialpoint, we have test batch size 80 and 43 test iterations,
@@ -8,7 +8,7 @@ test_iter: 1
 # Carry out testing every 500 training iterations.
 test_interval: 500
 # The base learning rate, momentum and the weight decay of the network.
-base_lr: 0.003
+base_lr: 0.001
 weight_decay : 0.0005
 solver_type : NESTEROV
 momentum: 0.9
@@ -23,7 +23,7 @@ display: 100
 max_iter: 1000000
 # snapshot intermediate results
 snapshot: 5000
-snapshot_prefix: "examples/kaggle_prototxt/model/fkp"
+snapshot_prefix: "/data/image_server/user/wangpeng/github/caffe-regression/kaggle_prototxt/model/fkp"
 # solver mode: CPU or GPU
 solver_mode: GPU
 


### PR DESCRIPTION
1. Modify network and deplay file according to latest caffe api and network defination.For example "layers" in old caffe has been changed to new format as "layer" , "CONVOLUTION" has been changed to "Convolution". 
2. Modify the base learning rate to 0.001 rather than 0.003.It seems like that training did not converge with base lr set to 0.003 
Thanks you for your caffe-regression example  